### PR TITLE
remove cmd out of error control

### DIFF
--- a/tracksuite/init.py
+++ b/tracksuite/init.py
@@ -53,7 +53,6 @@ class SSHClient(Client):
     def is_path(self, path):
         # Build the ssh command
         cmd = [f"[ -d {path} ] && exit 0 || exit 1"]
-        ret = self.exec(cmd)
         try:
             ret = self.exec(cmd)
             return ret.returncode == 0


### PR DESCRIPTION
With this the init of a new remote repo fails when the .git directory is not found while it should just start one from scratch. 
Triggered when using wellies/1.0.0 module with ssh deployment.