### PR TITLE
Add Sphinx documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+tracksuite/_version.py

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,13 @@
+SPHINXBUILD ?= sphinx-build
+SOURCEDIR = .
+BUILDDIR = _build
+
+.PHONY: html clean
+
+html:
+	$(SPHINXBUILD) -b html $(SOURCEDIR) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
+clean:
+	rm -rf $(BUILDDIR)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,30 @@
+Python API
+==========
+
+tracksuite package
+------------------
+
+.. automodule:: tracksuite
+   :members:
+   :undoc-members:
+
+tracksuite.deploy
+-----------------
+
+.. automodule:: tracksuite.deploy
+   :members:
+   :undoc-members:
+
+tracksuite.init
+---------------
+
+.. automodule:: tracksuite.init
+   :members:
+   :undoc-members:
+
+tracksuite.utils
+----------------
+
+.. automodule:: tracksuite.utils
+   :members:
+   :undoc-members:

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,14 @@
+Command line interface
+======================
+
+tracksuite-init
+---------------
+
+.. autoprogram:: tracksuite.init:main
+   :prog: tracksuite-init
+
+tracksuite-deploy
+-----------------
+
+.. autoprogram:: tracksuite.deploy:main
+   :prog: tracksuite-deploy

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -4,11 +4,11 @@ Command line interface
 tracksuite-init
 ---------------
 
-.. autoprogram:: tracksuite.init:main
+.. autoprogram:: tracksuite.init:main() --help
    :prog: tracksuite-init
 
 tracksuite-deploy
 -----------------
 
-.. autoprogram:: tracksuite.deploy:main
+.. autoprogram:: tracksuite.deploy:main() --help
    :prog: tracksuite-deploy

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,15 +1,16 @@
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
 
-project = 'tracksuite'
+sys.path.insert(0, os.path.abspath(".."))
+
+project = "tracksuite"
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.napoleon',
-    'sphinxcontrib.autoprogram',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinxcontrib.autoprogram",
 ]
 
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
-html_theme = 'alabaster'
+html_theme = "alabaster"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,15 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+project = 'tracksuite'
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinxcontrib.autoprogram',
+]
+
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+html_theme = 'alabaster'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,12 @@
+Tracksuite documentation
+=======================
+
+Tracksuite is a toolkit for deploying ecFlow suites through git repositories.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   usage
+   cli
+   api

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx>=4
+sphinxcontrib-autoprogram

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,31 @@
+Usage
+=====
+
+Installation
+------------
+
+To install tracksuite using pip (requires Python and ecFlow):
+
+.. code-block:: bash
+
+    python -m pip install .
+
+Command line examples
+---------------------
+
+To initialise the remote target git repository:
+
+.. code-block:: bash
+
+    tracksuite-init --target TARGET [--backup BACKUP] [--host HOST] [--user USER] [--force]
+
+To stage and deploy a suite:
+
+.. code-block:: bash
+
+    tracksuite-deploy --stage STAGE --local LOCAL --target TARGET [--backup BACKUP] [--host HOST] [--user USER] [--push] [--message MESSAGE]
+
+Overview
+--------
+
+.. image:: ../workflow.png

--- a/tracksuite/deploy.py
+++ b/tracksuite/deploy.py
@@ -137,7 +137,7 @@ class GitDeployment:
         Commits the current stage of the local repository.
         Throws exception if there is nothing to commit.
         Default commit message will be:
-            "deployed by {user} from {host}:{staging_dir}"
+        "deployed by {user} from {host}:{staging_dir}"
 
         Parameters:
             message(str): optional git commit message to append to default message
@@ -246,12 +246,14 @@ class GitDeployment:
         """
         Deploy the staged suite to the target repository.
         Steps:
+
             - git fetch remote repositories and check they are in sync
             - rsync the staged folder to the local repository
             - git add all the suite files and commit
             - git push to remotes
+        
         Default commit message will be:
-            "deployed by {user} from {host}:{staging_dir}"
+        "deployed by {user} from {host}:{staging_dir}"
 
         Parameters:
             message(str): optional git commit message to append to default message.
@@ -296,6 +298,7 @@ class GitDeployment:
         """
         Sync the remote repositories.
         Steps:
+        
             - git fetch remote repositories and check they are in sync
             - git push to backup if needed
         """

--- a/tracksuite/init.py
+++ b/tracksuite/init.py
@@ -107,6 +107,7 @@ def setup_remote(host, user, target_dir, remote=None, force=False):
     """
     Setup target and remote repositories.
     Steps:
+    
         - SSH to host, creates the git repository on target_dir
         - Create first dummy commit
         - (optional) git push to remote backup repository


### PR DESCRIPTION
## Summary
- add Sphinx docs with basic configuration
- document command line tools using `autoprogram`
- expose Python APIs in the documentation
- ignore autogenerated `_version.py`
- add Makefile and requirements for docs
- include usage guide from README
- switch to `sphinxcontrib.autoprogram`

## Testing
- `pytest -q` *(fails: command not found)*
- `sphinx-build -b html docs docs/_build/html` *(fails: command not found)*
