### PR TITLE
add package level logger name and use formatted warnings

### DIFF
--- a/tracksuite/__init__.py
+++ b/tracksuite/__init__.py
@@ -1,5 +1,13 @@
 # flake8: noqa
 
+import logging
+
+LOGGER = logging.getLogger("tracksuite")
+
+import warnings
+warnings.formatwarning = lambda mess, category, filename, lineno, *args: f"\033[93m[{category.__name__}] {filename}:{lineno}\n{mess}\n\033[0m"
+warn = warnings.warn
+
 from .deploy import GitDeployment
 from .init import setup_remote
 from .replace import replace_on_server
@@ -12,3 +20,5 @@ try:
 except ImportError:  # pragma: no cover
     # Local copy or not installed with setuptools
     __version__ = ""
+
+LOGGER.debug("tracksuite version: %s", __version__)

--- a/tracksuite/definition.py
+++ b/tracksuite/definition.py
@@ -1,7 +1,7 @@
 import argparse
-import logging as log
 import os
 
+from tracksuite import LOGGER, warn
 from tracksuite.ecflow_client import EcflowClient, save_definition
 from tracksuite.repos import GitRepositories
 
@@ -24,8 +24,10 @@ def update_definition_from_server(
         - Push the changes to the target repository
     """
 
-    log.warning(
-        "The 'update_definition_from_server' function of tracksuite is experimental. Do not use it in production!"
+    
+    warn(
+        "The 'update_definition_from_server' function of tracksuite is experimental. Do not use it in production!",
+        stacklevel=2
     )
 
     # Create the GitSuiteDefinition object
@@ -56,9 +58,9 @@ def update_definition_from_server(
         deployer.check_sync_remotes("target", "backup")
 
     # Commit the changes to the local repository
-    log.info("    -> Git commit")
+    LOGGER.info("    -> Git commit")
     if not deployer.commit(message="Update suite definition from server"):
-        log.info("Nothing to commit... aborting")
+        LOGGER.info("Nothing to commit... aborting")
         return False
 
     hash_check = deployer.get_hash_remote("target")
@@ -70,7 +72,7 @@ def update_definition_from_server(
 
     deployer.push("target")
     if deployer.backup_repo:
-        log.info(f"    -> Git push to backup repository {deployer.backup_repo}")
+        LOGGER.info(f"    -> Git push to backup repository {deployer.backup_repo}")
         deployer.push("backup")
 
 

--- a/tracksuite/deploy.py
+++ b/tracksuite/deploy.py
@@ -1,8 +1,8 @@
 import argparse
-import logging as log
 import os
 from filecmp import dircmp
 
+from tracksuite import LOGGER as log
 from tracksuite.repos import GitRepositories
 from tracksuite.utils import run_cmd
 

--- a/tracksuite/ecflow_client.py
+++ b/tracksuite/ecflow_client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations  # ← annotations are strings at run‑time
 
-import logging as log
+from tracksuite import LOGGER as log
 from typing import Any, cast
 
 try:

--- a/tracksuite/init.py
+++ b/tracksuite/init.py
@@ -1,12 +1,11 @@
 import argparse
-import logging as log
 import os
 import tempfile
 
 import git
 
-from .utils import run_cmd
-
+from tracksuite import LOGGER as log
+from tracksuite.utils import run_cmd
 
 class Client:
     def __init__(self, host, user):

--- a/tracksuite/replace.py
+++ b/tracksuite/replace.py
@@ -1,7 +1,7 @@
 import argparse
-import logging as log
 import os
 
+from tracksuite import LOGGER as log
 from tracksuite.ecflow_client import EcflowClient
 
 

--- a/tracksuite/repos.py
+++ b/tracksuite/repos.py
@@ -1,9 +1,9 @@
-import logging as log
 import os
 import tempfile
 
 import git
 
+from tracksuite import LOGGER as log
 
 class GitRepositories:
     def __init__(

--- a/tracksuite/revert.py
+++ b/tracksuite/revert.py
@@ -1,9 +1,8 @@
 import argparse
-import logging as log
 import os
 
 from tracksuite.repos import GitRepositories
-
+from tracksuite import LOGGER as log
 
 class GitRevert(GitRepositories):
     def __init__(


### PR DESCRIPTION
### Description

Previous logging used "root" as name, here a common name for all the package utilties is proposed.
Also replaces log.warning as it's deprecated in favour of warnings. Here a simple formatting is applied to a centralised `warn` wrapper.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 